### PR TITLE
add page cache clearing instruction to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ If you want to install the extension manually, please do these steps:
  * Copy the `src` folder into `system/modules/cache-control/classes`.
  * Open `system/modules/cache-control/config/autoload.php` and uncomment the class loader lines.
 
-After installing it you have to update the database structure.
+After installing it you have to update the database structure and clear your page cache.
 
 
 Limitations


### PR DESCRIPTION
You can only clear the page cache for cached pages that have been generated _after_ you installed the extension. You cannot clear the page cache for pages that already reside in the page cache.

To make this more clear I added `… and clear your page cache.`.